### PR TITLE
:bug: fix: improve deployment workflow

### DIFF
--- a/.github/workflows/deploy-nix-configs.yaml
+++ b/.github/workflows/deploy-nix-configs.yaml
@@ -50,6 +50,18 @@ jobs:
             echo "deploy_needed=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: "🚀 Start Deployment"
+        if: steps.changes.outputs.deploy_needed == 'true'
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: production
+          ref: ${{ github.sha }}
+          transient: false
+          auto_merge: false
+
       - name: "🏗️ Build and Deploy"
         if: steps.changes.outputs.deploy_needed == 'true'
         run: |
@@ -64,15 +76,15 @@ jobs:
           
           echo "✅ Deployment completed successfully"
 
-      - name: "📝 Create Deployment Status"
-        uses: bobheadxi/deployments@v1
+      - name: "✅ Finish Deployment"
         if: always()
+        uses: bobheadxi/deployments@v1
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: production
-          deployment_id: deploy-${{ github.run_id }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id || 'deploy-' + github.run_id }}
           desc: "Deployment ${{ job.status }}"
 
       - name: "📊 Generate Deployment Report"

--- a/.github/workflows/deploy-nix-configs.yaml
+++ b/.github/workflows/deploy-nix-configs.yaml
@@ -84,7 +84,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: production
-          deployment_id: ${{ steps.deployment.outputs.deployment_id || 'deploy-' + github.run_id }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id || format('deploy-{0}', github.run_id) }}
           desc: "Deployment ${{ job.status }}"
 
       - name: "📊 Generate Deployment Report"

--- a/.github/workflows/deploy-nix-configs.yaml
+++ b/.github/workflows/deploy-nix-configs.yaml
@@ -59,8 +59,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: production
           ref: ${{ github.sha }}
-          transient: false
-          auto_merge: false
 
       - name: "🏗️ Build and Deploy"
         if: steps.changes.outputs.deploy_needed == 'true'

--- a/.github/workflows/deploy-nix-configs.yaml
+++ b/.github/workflows/deploy-nix-configs.yaml
@@ -82,7 +82,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: production
-          deployment_id: ${{ steps.deployment.outputs.deployment_id || format('deploy-{0}', github.run_id) }}
+          # Use the deployment ID from the start step if available; otherwise, generate a unique fallback ID
+          # using the GitHub Actions run ID. This ensures we always have a valid deployment ID even if
+          # the start step didn't run or failed to create a deployment.
+          deployment_id: ${{ steps.deployment.outputs.deployment_id || format('deploy-{0}', github.run_id )}}
           desc: "Deployment ${{ job.status }}"
 
       - name: "📊 Generate Deployment Report"


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy-nix-configs.yaml` to enhance the deployment process by introducing a new deployment step and improving the handling of deployment IDs. 

### Deployment process improvements:

* **Start Deployment Step**: Added a new "🚀 Start Deployment" step that initiates deployments when `deploy_needed` is true. This step uses the `bobheadxi/deployments@v1` action to start the deployment with the appropriate environment and commit reference.

* **Finish Deployment Step**: Updated the "✅ Finish Deployment" step to use the deployment ID from the "Start Deployment" step. If the deployment ID is unavailable, it generates a fallback ID using the GitHub Actions run ID, ensuring robustness in deployment tracking.This pull request updates the deployment workflow in `.github/workflows/deploy-nix-configs.yaml` to streamline the deployment process and ensure proper handling of deployment statuses. The changes primarily involve introducing a new deployment step and refining the handling of deployment IDs.

### Deployment workflow improvements:

* **Added a new deployment initiation step**: Introduced the "🚀 Start Deployment" step to initiate deployments when changes require it, using the `bobheadxi/deployments@v1` action. This step includes configurations for the environment, reference, and authentication token.

* **Refined deployment completion step**: Replaced the "📝 Create Deployment Status" step with "✅ Finish Deployment," ensuring the deployment status is updated correctly. The deployment ID now dynamically uses the output from the "Start Deployment" step or falls back to a formatted string based on the GitHub run ID.- Add 'start deployment' step before build\n- Use deployment ID from start step for finish\n- Improve deployment status handling